### PR TITLE
fix: creating multiple loggers always returned the same logger

### DIFF
--- a/lib/otlp-logger.js
+++ b/lib/otlp-logger.js
@@ -43,7 +43,7 @@ function getOtlpLogger (opts) {
 
   logs.setGlobalLoggerProvider(loggerProvider)
 
-  const logger = logs.getLogger(opts.loggerName, opts.serviceVersion)
+  const logger = loggerProvider.getLogger(opts.loggerName, opts.serviceVersion)
 
   return {
     /**


### PR DESCRIPTION
Due to the use of `logs.getLogger` after setting the global `loggerProvider`, calling `getOtlpLogger` multiple times would always return the same logger after the first call. Without this fix the updated integration test will fail because all of the logs will be sent to the collector and none will be sent to the console.