### PR TITLE
fix(create-log-processor): accept variants of http/json

### DIFF
--- a/lib/create-log-processor.js
+++ b/lib/create-log-processor.js
@@ -60,7 +60,7 @@ function createExporter (exporterOptions) {
     return new OTLPLogExporter(exporterOptions?.grpcExporterOptions)
   }
 
-  if (exporterProtocol === 'http') {
+  if (exporterProtocol === 'http' || exporterProtocol === 'http/json') {
     const {
       OTLPLogExporter
     } = require('@opentelemetry/exporter-logs-otlp-http')


### PR DESCRIPTION
Just a tiny bug that took me a couple of hours to discover why my logs were being exported using grpc.

Great library by the way!