### PR TITLE
An option to pass an existing resource and skip resource auto-dection

### DIFF
--- a/lib/otlp-logger.js
+++ b/lib/otlp-logger.js
@@ -18,12 +18,13 @@ const { createLogProcessor } = require('./create-log-processor')
  * @property {string} loggerName
  * @property {string} serviceVersion
  * @property {import('./create-log-processor').LogRecordProcessorOptions | import('./create-log-processor').LogRecordProcessorOptions[]} [logRecordProcessorOptions]
- * @property {Object} [resourceAttributes={}]
+ * @property {import('@opentelemetry/resources').ResourceAttributes} [resourceAttributes={}]
+ * @property {import('@opentelemetry/resources').IResource} [resource] - If not provided, an autodetected resource will be used
  *
  * @param {Options} opts
  */
 function getOtlpLogger (opts) {
-  const detectedResource = detectResourcesSync({
+  const resource = opts.resource ?? detectResourcesSync({
     detectors: [
       envDetectorSync,
       hostDetectorSync,
@@ -32,7 +33,7 @@ function getOtlpLogger (opts) {
     ]
   })
   const loggerProvider = new LoggerProvider({
-    resource: detectedResource.merge(
+    resource: resource.merge(
       new Resource({ ...opts.resourceAttributes })
     )
   })


### PR DESCRIPTION
Hi! This is is a small, backwards compatible change.

The caller may have an already set up OLTP resource, potentially with async attributes, and they may not want auto-detected resource attributes.  I have both of these use-cases, and I think this is the simplest way to support those.

